### PR TITLE
Add support for the upcoming Aurora 0.7+

### DIFF
--- a/AuroraTranslationTool/TranslationPackData.cs
+++ b/AuroraTranslationTool/TranslationPackData.cs
@@ -214,8 +214,12 @@ namespace AuroraTranslationTool {
                                    };
             proc.Start();
             proc.WaitForExit();
+            
+            // Change the resx2Bin build flags based on the version of the localization
+            var resx2BinFlags = "/I"; float version = 0.0f;
+            if (float.TryParse(GetVersion(src), out version) == true ) { if ( version >= 0.7f) resx2BinFlags = ""; }
             proc.StartInfo = new ProcessStartInfo {
-                                                      Arguments = "/NOLOGO /I DynamicStrings.resx",
+                                                      Arguments = "/NOLOGO " + resx2BinFlags + " DynamicStrings.resx",
                                                       WorkingDirectory = dir,
                                                       FileName = resx2Bin
                                                   };


### PR DESCRIPTION
Aurora switched to using switched from index based keys to key/value pairs.  Versions less than 0.6 and older, I assume should use the original compilation method, and versions 0.7 and newer should use the new one.

Feel free to update this code however you want.